### PR TITLE
Stable fallback images generation

### DIFF
--- a/themes/frontierline-firefox/content-views/content-summary.php
+++ b/themes/frontierline-firefox/content-views/content-summary.php
@@ -12,7 +12,7 @@
       <?php if (has_post_thumbnail()) :
         the_post_thumbnail('post-large');
       else : ?>
-        <img class="wp-post-image image-fallback color-<?php echo rand(1, 6); ?>" width="600" height="330" src="<?php echo get_template_directory_uri(); ?>/img/fallbacks/pattern-<?php echo rand(1, 6); ?>.png">
+        <img class="wp-post-image image-fallback color-<?php echo frontierline_fallback_image_num(get_the_ID()); ?>" width="600" height="330" src="<?php echo get_template_directory_uri(); ?>/img/fallbacks/pattern-<?php echo frontierline_fallback_image_num(get_the_ID()); ?>.png">
       <?php endif; ?>
       </div>
 

--- a/themes/frontierline/content-views/content-mini.php
+++ b/themes/frontierline/content-views/content-mini.php
@@ -12,7 +12,7 @@
   ?>
     <img class="post-image" width="300" height="165" alt="" src="<?php echo get_template_directory_uri(); ?>/img/place-thumb.png" data-src="<?php echo $thumb_url[0]; ?>">
   <?php else : ?>
-    <img class="post-image image-fallback color-<?php echo rand(1, 6); ?>" width="300" height="165" alt="" src="<?php echo get_template_directory_uri(); ?>/img/place-thumb.png" data-src="<?php echo get_template_directory_uri(); ?>/img/fallbacks/pattern-<?php echo rand(1, 6); ?>.png">
+    <img class="post-image image-fallback color-<?php echo frontierline_fallback_image_num(get_the_ID()); ?>" width="300" height="165" alt="" src="<?php echo get_template_directory_uri(); ?>/img/place-thumb.png" data-src="<?php echo get_template_directory_uri(); ?>/img/fallbacks/pattern-<?php echo frontierline_fallback_image_num(get_the_ID()); ?>.png">
   <?php endif; ?>
     <h5 class="entry-title"><?php the_title(); ?></h5>
   </a>

--- a/themes/frontierline/content-views/content-summary.php
+++ b/themes/frontierline/content-views/content-summary.php
@@ -12,7 +12,7 @@
       <?php if (has_post_thumbnail()) :
         the_post_thumbnail('post-large');
       else : ?>
-        <img class="wp-post-image image-fallback color-<?php echo rand(1, 6); ?>" width="600" height="330" src="<?php echo get_template_directory_uri(); ?>/img/fallbacks/pattern-<?php echo rand(1, 6); ?>.png">
+        <img class="wp-post-image image-fallback color-<?php echo frontierline_fallback_image_num(get_the_ID()); ?>" width="600" height="330" src="<?php echo get_template_directory_uri(); ?>/img/fallbacks/pattern-<?php echo frontierline_fallback_image_num(get_the_ID()); ?>.png">
       <?php endif; ?>
       </div>
 

--- a/themes/frontierline/functions.php
+++ b/themes/frontierline/functions.php
@@ -637,6 +637,16 @@ add_action('admin_notices', 'frontierline_image_reminder');
 
 
 /**
+ * Get a pseudo-random number for the given post.
+ */
+function frontierline_fallback_image_num( $post_id ) {
+  $post_name = get_post($post_id)->post_name;
+  $hash_number = hexdec(substr(md5($post_name), 0, 8));
+  return ($hash_number%6)+1;
+}
+
+
+/**
  * Adds custom classes to the array of body classes.
  */
 function frontierline_body_classes($classes) {


### PR DESCRIPTION
Currently with every page refresh, the fallback image is chosen randomly. That means the same post changes the image for each page load, Actually it can have different fallback images in the list on homepage and in the header categories menu on the same page.

This changes makes generating the fallback image stable with the post slug. So unless you change the post slug, the fallback image for the particular post is always and everywhere the same.