### PR TITLE
Add setting to hide the newsletter form for posts or pages

### DIFF
--- a/themes/frontierline-firefox/includes/newsletter-form.php
+++ b/themes/frontierline-firefox/includes/newsletter-form.php
@@ -5,7 +5,7 @@
 
 ?>
 
-<?php if ((is_single() && get_option('frontierline_newsform_posts') == 1) || (is_page() && get_option('frontierline_newsform_pages') == 1)) : ?>
+<?php if ((is_single() && get_option('frontierline_newsform_posts', 1) == 1) || (is_page() && get_option('frontierline_newsform_pages', 1) == 1) || (!is_singular() && get_option('frontierline_newsform_other', 1) == 1)) : ?>
 <aside id="newsletter-subscribe" class="section newsletter-firefox">
   <form id="newsletter_form" class="content newsletter_form" name="newsletter_form" action="https://www.mozilla.org/en-US/newsletter/" method="post" data-blog="<?php echo esc_attr(get_bloginfo('name', 'display')); ?>">
     <input type="hidden" id="newsletters" name="newsletters" value="mozilla-and-you">

--- a/themes/frontierline-firefox/includes/newsletter-form.php
+++ b/themes/frontierline-firefox/includes/newsletter-form.php
@@ -5,6 +5,7 @@
 
 ?>
 
+<?php if ((is_single() && get_option('frontierline_newsform_posts') == 1) || (is_page() && get_option('frontierline_newsform_pages') == 1)) : ?>
 <aside id="newsletter-subscribe" class="section newsletter-firefox">
   <form id="newsletter_form" class="content newsletter_form" name="newsletter_form" action="https://www.mozilla.org/en-US/newsletter/" method="post" data-blog="<?php echo esc_attr(get_bloginfo('name', 'display')); ?>">
     <input type="hidden" id="newsletters" name="newsletters" value="mozilla-and-you">
@@ -350,3 +351,4 @@
 
   </form>
 </aside>
+<?php endif; ?>

--- a/themes/frontierline/functions.php
+++ b/themes/frontierline/functions.php
@@ -107,6 +107,21 @@ function frontierline_admin_init(){
 
   register_setting(
     'reading',
+    'frontierline_newsform_other',
+    array(
+      'default' => 1,
+    )
+  );
+  add_settings_field(
+    'newsform_other',
+    __('Show newsletter form under posts lists and other views', 'frontierline'),
+    'frontierline_settings_field_newsform_other',
+    'reading',
+    'default'
+  );
+
+  register_setting(
+    'reading',
     'frontierline_share_posts'
   );
   add_settings_field(
@@ -170,6 +185,22 @@ function frontierline_settings_field_newsform_pages() { ?>
       <?php _e('Show newsletter form on Pages', 'frontierline'); ?>
     </span>
             <p class="description"><?php _e('Adds a subscribe form to the Mozilla newsletter to the bottom of static Pages.', 'frontierline'); ?></p>
+        </label>
+    </div>
+    <?php
+}
+
+/**
+ * Renders the Newsletter form setting field for post lists and other views.
+ */
+function frontierline_settings_field_newsform_other() { ?>
+    <div class="layout newsform-other">
+        <label>
+            <input type="checkbox" id="frontierline_newsform_other" name="frontierline_newsform_other" value="1" <?php checked( '1', get_option('frontierline_newsform_other') ); ?>>
+            <span>
+      <?php _e('Show newsletter form under posts lists and other views', 'frontierline'); ?>
+    </span>
+            <p class="description"><?php _e('Adds a subscribe form to the Mozilla newsletter to the bottom of posts lists and other views.', 'frontierline'); ?></p>
         </label>
     </div>
     <?php

--- a/themes/frontierline/functions.php
+++ b/themes/frontierline/functions.php
@@ -77,6 +77,36 @@ require get_template_directory() . '/inc/customizer.php';
 function frontierline_admin_init(){
   register_setting(
     'reading',
+    'frontierline_newsform_posts',
+    array(
+      'default' => 1,
+    )
+);
+  add_settings_field(
+    'newsform_posts',
+    __('Show newsletter form under posts', 'frontierline'),
+    'frontierline_settings_field_newsform_posts',
+    'reading',
+    'default'
+  );
+
+  register_setting(
+    'reading',
+    'frontierline_newsform_pages',
+    array(
+      'default' => 1,
+    )
+  );
+  add_settings_field(
+    'newsform_pages',
+    __('Show newsletter form on Pages', 'frontierline'),
+    'frontierline_settings_field_newsform_pages',
+    'reading',
+    'default'
+  );
+
+  register_setting(
+    'reading',
     'frontierline_share_posts'
   );
   add_settings_field(
@@ -112,6 +142,38 @@ function frontierline_admin_init(){
   );
 }
 add_action('admin_init', 'frontierline_admin_init');
+
+/**
+ * Renders the Newsletter form setting field for posts.
+ */
+function frontierline_settings_field_newsform_posts() { ?>
+    <div class="layout newsform-posts">
+        <label>
+            <input type="checkbox" id="frontierline_newsform_posts" name="frontierline_newsform_posts" value="1" <?php checked( '1', get_option('frontierline_newsform_posts') ); ?>>
+            <span>
+      <?php _e('Show newsletter form under posts', 'frontierline'); ?>
+    </span>
+            <p class="description"><?php _e('Adds a subscribe form to the Mozilla newsletter to the bottom of blog articles.', 'frontierline'); ?></p>
+        </label>
+    </div>
+    <?php
+}
+
+/**
+ * Renders the Newsletter form setting field for pages.
+ */
+function frontierline_settings_field_newsform_pages() { ?>
+    <div class="layout newsform-pages">
+        <label>
+            <input type="checkbox" id="frontierline_newsform_pages" name="frontierline_newsform_pages" value="1" <?php checked( '1', get_option('frontierline_newsform_pages') ); ?>>
+            <span>
+      <?php _e('Show newsletter form on Pages', 'frontierline'); ?>
+    </span>
+            <p class="description"><?php _e('Adds a subscribe form to the Mozilla newsletter to the bottom of static Pages.', 'frontierline'); ?></p>
+        </label>
+    </div>
+    <?php
+}
 
 /**
  * Renders the Add Sharing setting field for posts.

--- a/themes/frontierline/includes/newsletter-form.php
+++ b/themes/frontierline/includes/newsletter-form.php
@@ -5,7 +5,7 @@
 
 ?>
 
-<?php if ((is_single() && get_option('frontierline_newsform_posts') == 1) || (is_page() && get_option('frontierline_newsform_pages') == 1)) : ?>
+<?php if ((is_single() && get_option('frontierline_newsform_posts', 1) == 1) || (is_page() && get_option('frontierline_newsform_pages', 1) == 1) || (!is_singular() && get_option('frontierline_newsform_other', 1) == 1)) : ?>
 <aside id="newsletter-subscribe" class="section">
   <form id="newsletter_form" class="content newsletter_form" name="newsletter_form" action="https://www.mozilla.org/en-US/newsletter/" method="post" data-blog="<?php echo esc_attr(get_bloginfo('name', 'display')); ?>">
     <input type="hidden" id="newsletters" name="newsletters" value="mozilla-foundation">

--- a/themes/frontierline/includes/newsletter-form.php
+++ b/themes/frontierline/includes/newsletter-form.php
@@ -5,6 +5,7 @@
 
 ?>
 
+<?php if ((is_single() && get_option('frontierline_newsform_posts') == 1) || (is_page() && get_option('frontierline_newsform_pages') == 1)) : ?>
 <aside id="newsletter-subscribe" class="section">
   <form id="newsletter_form" class="content newsletter_form" name="newsletter_form" action="https://www.mozilla.org/en-US/newsletter/" method="post" data-blog="<?php echo esc_attr(get_bloginfo('name', 'display')); ?>">
     <input type="hidden" id="newsletters" name="newsletters" value="mozilla-foundation">
@@ -67,3 +68,4 @@
 
   </form>
 </aside>
+<?php endif; ?>

--- a/themes/frontierline/js/basket-client.js
+++ b/themes/frontierline/js/basket-client.js
@@ -1,11 +1,13 @@
 (function(ga) {
     'use strict';
 
-    // !! this file assumes only one signup form per page !!
+    // !! this script assumes only one signup form per page !!
 
     var newsletterForm = document.getElementById('newsletter_form');
     var newsletterWrapper = document.getElementById('form-contents');
-    var blogName = newsletterForm.getAttribute('data-blog');
+    if (newsletterForm) {
+        var blogName = newsletterForm.getAttribute('data-blog');
+    }
 
     // handle errors
     var errorArray = [];
@@ -121,5 +123,7 @@
         return false;
     }
 
-    newsletterForm.addEventListener('submit', newsletterSubscribe, false);
+    if (newsletterForm) {
+        newsletterForm.addEventListener('submit', newsletterSubscribe, false);
+    }
 })();


### PR DESCRIPTION
For Mozilla.cz we do not want to show the newsletter form until it's available in Czech one day. This allows to hide it.