### PR TITLE
Valid HTML5

### DIFF
--- a/themes/frontierline-firefox/includes/newsletter-form.php
+++ b/themes/frontierline-firefox/includes/newsletter-form.php
@@ -27,7 +27,7 @@
       <div class="form-details">
         <div class="field field-country">
           <label for="country"><?php _e('Country', 'frontierline'); ?></label>
-          <select aria-required="true" id="country" name="country" required="required">
+          <select id="country" name="country" required="required">
             <option value="" selected="selected"><?php _e('- select -', 'frontierline'); ?></option>
             <option value="af">Afghanistan</option>
             <option value="qz">Akrotiri</option>
@@ -306,7 +306,7 @@
 
         <div class="field field-language">
           <label for="lang"><?php _e('Language', 'frontierline'); ?></label>
-          <select aria-required="true" id="lang" name="lang" required="required">
+          <select id="lang" name="lang" required="required">
             <option value="id">Bahasa Indonesia</option>
             <option value="de">Deutsch</option>
             <option value="en" selected="selected">English</option>

--- a/themes/frontierline/header.php
+++ b/themes/frontierline/header.php
@@ -4,7 +4,7 @@
   <meta charset="<?php bloginfo('charset'); ?>">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <link rel="copyright" href="#license">
+  <link rel="license" href="#license">
   <link rel="profile" href="http://gmpg.org/xfn/11">
   <link rel="shortcut icon" type="image/png" href="<?php site_icon_url(128, get_template_directory_uri().'/img/favicon.png'); ?>">
 
@@ -49,4 +49,4 @@
 
     <?php get_template_part('includes/site-intro'); ?>
 
-    <main id="content" role="main">
+    <main id="content">

--- a/themes/frontierline/image.php
+++ b/themes/frontierline/image.php
@@ -11,7 +11,7 @@
 
     <article id="post-<?php the_ID(); ?>" <?php post_class('image-attachment'); ?>>
       <header class="entry-header">
-        <h1 class="entry-title"><?php the_title(); ?></h2>
+        <h1 class="entry-title"><?php the_title(); ?></h1>
         <div class="entry-info">
           <?php
             $metadata = wp_get_attachment_metadata();

--- a/themes/frontierline/includes/categories.php
+++ b/themes/frontierline/includes/categories.php
@@ -8,7 +8,7 @@
   $categories = get_categories('number=8&orderby=count&order=desc&hierarchical=0&depth=1');
 ?>
 
-<aside id="categories" role="complementary" class="can-stick">
+<aside id="categories" class="can-stick">
   <div class="content">
     <h3 class="module-title"><?php _e('More articles', 'frontierline'); ?></h3>
 

--- a/themes/frontierline/includes/newsletter-form.php
+++ b/themes/frontierline/includes/newsletter-form.php
@@ -27,7 +27,7 @@
       <div class="form-details">
         <div class="field field-language">
           <label for="lang"><?php _e('Language', 'frontierline'); ?></label>
-          <select aria-required="true" id="lang" name="lang" required="required">
+          <select id="lang" name="lang" required="required">
             <option value="de">Deutsch</option>
             <option value="en" selected="selected">English</option>
             <option value="es">Español</option>

--- a/themes/frontierline/includes/social-share.php
+++ b/themes/frontierline/includes/social-share.php
@@ -16,7 +16,7 @@ $share_via = sanitize_text_field(get_option('frontierline_twitter_username'));
   <ul>
     <li><a rel="external nofollow noopener" target="_blank" class="twitter" data-network="Twitter" data-blog="<?php echo $blog_name; ?>" href="https://twitter.com/intent/tweet/?text=<?php echo $share_text; ?>&amp;url=<?php echo $share_url; ?><?php if (get_option('frontierline_twitter_username')) : ?>&amp;via=<?php echo $share_via; endif ?>&amp;utm_source=twitter&amp;utm_medium=social&amp;utm_campaign=shares_from_blog">Twitter</a></li>
 <?php /* Remove Facebook sharing for the time being...
-    <li><a rel="external nofollow noopener" target="_blank" class="facebook" data-network="Facebook" data-blog="<?php echo $blog_name; ?>" href="https://www.facebook.com/sharer/sharer.php?s=100&amp;p[url]=<?php echo urlencode($share_url); ?>&amp;p[title]=<?php echo urlencode(html_entity_decode($share_text, ENT_COMPAT, 'UTF-8')); ?>&amp;utm_source=facebook&amp;utm_medium=social&amp;utm_campaign=shares_from_blog">Facebook</a></li>
+    <li><a rel="external nofollow noopener" target="_blank" class="facebook" data-network="Facebook" data-blog="<?php echo $blog_name; ?>" href="https://www.facebook.com/sharer/sharer.php?s=100&amp;p%5Burl%5D=<?php echo urlencode($share_url); ?>&amp;p%5Btitle%5D=<?php echo urlencode(html_entity_decode($share_text, ENT_COMPAT, 'UTF-8')); ?>&amp;utm_source=facebook&amp;utm_medium=social&amp;utm_campaign=shares_from_blog">Facebook</a></li>
 */ ?>
   </ul>
 </div>

--- a/themes/frontierline/sidebar.php
+++ b/themes/frontierline/sidebar.php
@@ -4,7 +4,7 @@
  */
 ?>
 
-<aside id="sidebar" class="section widgets can-stick" role="complementary">
+<aside id="sidebar" class="section widgets can-stick">
   <div class="content">
   <?php dynamic_sidebar('sidebar'); ?>
   </div>


### PR DESCRIPTION
- Potentially bad value copyright for attribute rel on element link: The keyword copyright for the rel attribute should not be used. Consider using license instead.
- The main role is unnecessary for element main.
- The complementary role is unnecessary for element aside.
- Attribute aria-required is unnecessary for elements that have attribute required.
- Bad value for attribute href on element a: Illegal character in query: [ is not allowed.

See https://validator.w3.org/nu/?doc=https%3A%2F%2Fblog.mozilla.org%2F and https://validator.w3.org/nu/?doc=https%3A%2F%2Fblog.mozilla.org%2Fblog%2F2018%2F01%2F16%2Fmozilla-files-suit-fcc-protect-net-neutrality%2F

Note: This PR is rather simple, it collides with other PRs. If you won't mind, please keep this for later as it is probably the easiest one to rebase. ;)