### PR TITLE
Distinguish the Explore menu from the main responsive menu

### DIFF
--- a/themes/frontierline/sass/components/navigation/_nav-util.scss
+++ b/themes/frontierline/sass/components/navigation/_nav-util.scss
@@ -72,7 +72,8 @@
     }
 
     .nav-util-sidebar a:before {
-        background-position: 0 0;
+        background-position: 0 -40px;
+        transform: rotate(-90deg);
     }
 
     .nav-util-sidebar a.close:before {

--- a/themes/frontierline/style.css
+++ b/themes/frontierline/style.css
@@ -559,7 +559,7 @@ textarea:-moz-ui-invalid:not(output), input[type=email]:-moz-ui-invalid:not(outp
 #nav-util a { color: #fff; font-weight: bold; text-decoration: none; padding-left: 25px; position: relative; }
 #nav-util a:hover, #nav-util a:focus { text-decoration: underline; }
 #nav-util a:before { -webkit-background-size: 25px 200px; background-size: 25px 200px; background-image: url("img/icon-sprite.svg"); background-repeat: no-repeat; bottom: 0; content: ''; display: inline-block; height: 18px; left: 0; position: absolute; width: 20px; }
-#nav-util .nav-util-sidebar a:before { background-position: 0 0; }
+#nav-util .nav-util-sidebar a:before { background-position: 0 -40px; transform: rotate(-90deg); }
 #nav-util .nav-util-sidebar a.close:before { background-position: 0 -20px; }
 #nav-util .nav-util-categories a:before { background-position: 0 -40px; }
 #nav-util .nav-util-categories a.close:before { background-position: 0 -60px; }


### PR DESCRIPTION
Use the arrow instead of the hamburger icon for the Explore menu to better distinguish on mobile.

before:
![snimek obrazovky 2018-01-18 v 15 25 26](https://user-images.githubusercontent.com/3941344/35102668-da80cd56-fc63-11e7-9311-f8951cd20cb0.png)

after:
![snimek obrazovky 2018-01-18 v 15 25 33](https://user-images.githubusercontent.com/3941344/35102673-de9acc84-fc63-11e7-9dac-59d064411642.png)
