### PR TITLE
Hide Explore link when the sidebar is empty

### DIFF
--- a/themes/frontierline/includes/nav-util.php
+++ b/themes/frontierline/includes/nav-util.php
@@ -6,7 +6,7 @@
 
 <nav id="nav-util" class="can-stick <?php if (get_theme_mod('frontierline_category_drawer') === '1') : ?>has-categories<?php endif; ?>">
   <ul class="content">
-    <li class="nav-util-sidebar"><a href="#sidebar" aria-controls="sidebar" id="toggle-sidebar"><?php _e('Explore', 'frontierline'); ?></a></li>
+    <li class="nav-util-sidebar"><?php if (is_active_sidebar('sidebar')) : ?><a href="#sidebar" aria-controls="sidebar" id="toggle-sidebar"><?php _e('Explore', 'frontierline'); ?></a><?php endif; ?></li>
    <?php if (get_theme_mod('frontierline_category_drawer') === '1') : ?>
     <li class="nav-util-categories"><a href="#categories" aria-controls="categories" id="toggle-categories"><?php _e('Categories', 'frontierline'); ?></a></li>
    <?php endif; ?>

--- a/themes/frontierline/includes/nav-util.php
+++ b/themes/frontierline/includes/nav-util.php
@@ -7,9 +7,7 @@
 <nav id="nav-util" class="can-stick <?php if (get_theme_mod('frontierline_category_drawer') === '1') : ?>has-categories<?php endif; ?>">
   <ul class="content">
     <li class="nav-util-sidebar"><?php if (is_active_sidebar('sidebar')) : ?><a href="#sidebar" aria-controls="sidebar" id="toggle-sidebar"><?php _e('Explore', 'frontierline'); ?></a><?php endif; ?></li>
-   <?php if (get_theme_mod('frontierline_category_drawer') === '1') : ?>
-    <li class="nav-util-categories"><a href="#categories" aria-controls="categories" id="toggle-categories"><?php _e('Categories', 'frontierline'); ?></a></li>
-   <?php endif; ?>
+    <li class="nav-util-categories"><?php if (get_theme_mod('frontierline_category_drawer') === '1') : ?><a href="#categories" aria-controls="categories" id="toggle-categories"><?php _e('Categories', 'frontierline'); ?></a><?php endif; ?></li>
     <li class="nav-util-search"><?php get_search_form(); ?></li>
   </ul>
 </nav>


### PR DESCRIPTION
This is just a minor fix for the case when there are no widgets in the sidebar.