### PR TITLE
Style changes to improve readability of These Weeks in Firefox posts

### DIFF
--- a/themes/frontierline-nightly/style.css
+++ b/themes/frontierline-nightly/style.css
@@ -160,3 +160,33 @@ Version:        1.0
         width: 980px;
     }
 }
+
+/* "These weeks in Firefox" posts special rules */
+@media screen and (min-width: 760px) {
+    .single .category-news .entry-header .entry-title,
+    .page .category-news .entry-header .entry-title {
+        font-size: 2rem;
+    }
+}
+
+@media screen and (min-width: 1000px) {
+    .single .category-news .entry-header .entry-title,
+    .page .category-news .entry-header .entry-title {
+        font-size: 3rem;
+    }
+}
+
+.single .category-news .entry-content h3,
+.page .category-news .entry-content h3,
+.single .category-news .entry-content h4,
+.page .category-news .entry-content h4 {
+    color: white;
+    background-color: black;
+    padding: 0.3rem;
+}
+
+.single .category-news .entry-content h4,
+.page .category-news .entry-content h4 {
+    font-weight: normal;
+}
+/* end of "These weeks in Firefox" posts special rules */


### PR DESCRIPTION
* Smaller entry titles to avoid having the week number on a separate line
* Style h3 and h4 titles to make the different sections more identifiable

all the style changes only affect posts in the 'News' category (.category-news)